### PR TITLE
enable additional casbin versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-casbin==0.8.4
+casbin>=0.8.4
 click==7.1.2
 flask==1.1.2
 itsdangerous==1.1.0


### PR DESCRIPTION
I see there are frequently newer versions of casbin being released, and I don't think there is any reason to be so restrictive on casbin version requirements here in flask-authz.

Perhaps we can allow more recent versions of casbin to be installed, until we know of any breaking change?

