### PR TITLE
Fix: Specify fixed nodejs version in ci workflow and add p3.10 to releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9, 3.10 ]
         os: [ ubuntu-18.04, macOS-latest, windows-latest ]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
         os: [ ubuntu-18.04, macOS-latest, windows-latest ]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v1
+        with:
+          node-version: '16'
 
       - name: Setup
         run: npm install -g semantic-release @semantic-release/github @semantic-release/changelog @semantic-release/commit-analyzer @semantic-release/git @semantic-release/release-notes-generator semantic-release-pypi


### PR DESCRIPTION
Fix: https://github.com/pycasbin/flask-authz/issues/43

- Specify nodejs version 16 as sematic-release require 14.17 or above
- Add python3.10 to the list of releases